### PR TITLE
Fix board loading and endgame handling

### DIFF
--- a/AutoChess/Board.cs
+++ b/AutoChess/Board.cs
@@ -39,6 +39,15 @@ namespace AutoChess
 
         public void LoadFEN(string fen)
         {
+            // Clear the current board before loading a new position
+            for (int r = 0; r < 8; r++)
+            {
+                for (int c = 0; c < 8; c++)
+                {
+                    board[r, c] = '\0';
+                }
+            }
+
             string[] parts = fen.Split(' ');
             string[] rows = parts[0].Split('/');
 

--- a/AutoChess/ChessEngine.cs
+++ b/AutoChess/ChessEngine.cs
@@ -139,7 +139,8 @@ namespace AutoChess
                 {
                     NotifyPlayerOutcome("Congratulations You have won");
                 }
-               
+
+                return;
             }
 
             // Convert the move from algebraic notation to board coordinates


### PR DESCRIPTION
## Summary
- clear board before loading new FEN data
- stop processing moves after `(none)` result

## Testing
- `dotnet build AutoChess/AutoChess.csproj -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68402d504dec8327a7fa9d12dad531bb