### PR TITLE
Add unit tests and configurable engine path

### DIFF
--- a/AutoChess.Tests/AutoChess.Tests.csproj
+++ b/AutoChess.Tests/AutoChess.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../AutoChess/AutoChess.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="fake_stockfish.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/AutoChess.Tests/Tests/BoardTests.cs
+++ b/AutoChess.Tests/Tests/BoardTests.cs
@@ -1,0 +1,44 @@
+using AutoChess;
+using Xunit;
+
+namespace AutoChess.Tests
+{
+    public class BoardTests
+    {
+        [Fact]
+        public void LoadFEN_ShouldSetPiecesAndTurn()
+        {
+            var board = new Board();
+            const string fen = "8/8/8/3p4/8/8/8/8 b - - 0 1";
+            board.LoadFEN(fen);
+
+            Assert.Equal('p', board.GetPieceAt(3, 3));
+            Assert.False(board.IsWhiteTurn);
+        }
+
+        [Fact]
+        public void GetFEN_ShouldReturnCurrentPosition()
+        {
+            var board = new Board();
+            const string fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
+            board.LoadFEN(fen);
+
+            var result = board.GetFEN();
+
+            Assert.StartsWith("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w", result);
+        }
+
+        [Fact]
+        public void Clone_ShouldReturnDeepCopy()
+        {
+            var board = new Board();
+            board.LoadFEN("8/8/8/8/8/8/8/R3K2R w - - 0 1");
+
+            var clone = board.Clone();
+            board.SetPieceAt(7, 0, '\0');
+
+            Assert.Equal('R', clone.GetPieceAt(7, 0));
+            Assert.NotEqual(board.GetPieceAt(7, 0), clone.GetPieceAt(7, 0));
+        }
+    }
+}

--- a/AutoChess.Tests/Tests/ChessEngineTests.cs
+++ b/AutoChess.Tests/Tests/ChessEngineTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Threading.Tasks;
+using AutoChess;
+using Xunit;
+
+namespace AutoChess.Tests
+{
+    public class ChessEngineTests
+    {
+        [Fact]
+        public async Task GetBestMove_ReturnsValueFromBackend()
+        {
+            var script = Path.Combine(AppContext.BaseDirectory, "fake_stockfish.sh");
+            var engine = new ChessEngine("/bin/bash", script);
+            engine.LoadPosition("8/8/8/8/8/8/8/8 w - - 0 1");
+            var bestMove = await engine.GetBestMove(1);
+            engine.StopStockfish();
+
+            Assert.Equal("a1a2", bestMove);
+        }
+    }
+}

--- a/AutoChess.Tests/fake_stockfish.sh
+++ b/AutoChess.Tests/fake_stockfish.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+while read line; do
+  if [[ "$line" == "quit" ]]; then
+    exit 0
+  fi
+  if [[ $line == go* ]]; then
+    echo "bestmove a1a2"
+  fi
+  # ignore other commands
+done

--- a/AutoChess.sln
+++ b/AutoChess.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.12.35521.163 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoChess", "AutoChess\AutoChess.csproj", "{4C168B02-2E6B-4A37-869C-4FB1759C8349}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoChess.Tests", "AutoChess.Tests\AutoChess.Tests.csproj", "{898EB637-6372-4EA3-AF30-394445BB37A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{4C168B02-2E6B-4A37-869C-4FB1759C8349}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4C168B02-2E6B-4A37-869C-4FB1759C8349}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C168B02-2E6B-4A37-869C-4FB1759C8349}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4C168B02-2E6B-4A37-869C-4FB1759C8349}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {4C168B02-2E6B-4A37-869C-4FB1759C8349}.Release|Any CPU.Build.0 = Release|Any CPU
+                {898EB637-6372-4EA3-AF30-394445BB37A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {898EB637-6372-4EA3-AF30-394445BB37A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {898EB637-6372-4EA3-AF30-394445BB37A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {898EB637-6372-4EA3-AF30-394445BB37A3}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/AutoChess/ChessEngine.cs
+++ b/AutoChess/ChessEngine.cs
@@ -17,6 +17,9 @@ namespace AutoChess
         private StreamWriter stockfishInput;
         private StreamReader stockfishOutput;
 
+        private readonly string enginePath;
+        private readonly string? engineArguments;
+
         public Action RefreshBoardCallback { get; set; }
         public Action<string> RoundOverCallback { get; set; }
 
@@ -25,8 +28,14 @@ namespace AutoChess
 
 
 
-        public ChessEngine()
+        public ChessEngine() : this("../../../stockfish/stockfish.exe")
         {
+        }
+
+        public ChessEngine(string enginePath, string? arguments = null)
+        {
+            this.enginePath = enginePath;
+            this.engineArguments = arguments;
             StartStockfish();
         }
 
@@ -36,7 +45,8 @@ namespace AutoChess
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "../../../stockfish/stockfish.exe",
+                    FileName = enginePath,
+                    Arguments = engineArguments ?? string.Empty,
                     RedirectStandardInput = true,
                     RedirectStandardOutput = true,
                     UseShellExecute = false,


### PR DESCRIPTION
## Summary
- add Board and ChessEngine tests
- make ChessEngine accept custom engine path and arguments
- include fake Stockfish script for testing
- update solution file with test project

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d327eb808327bfef410cbbf1a185