### PR TITLE
Fix chess engine constructors

### DIFF
--- a/AutoChess/ChessEngine.cs
+++ b/AutoChess/ChessEngine.cs
@@ -28,11 +28,15 @@ namespace AutoChess
 
 
 
-        public ChessEngine() : this("../../../stockfish/stockfish.exe")
+        public ChessEngine() : this("../../../stockfish/stockfish.exe", null)
         {
         }
 
-        public ChessEngine(string enginePath, string? arguments = null)
+        public ChessEngine(string enginePath) : this(enginePath, null)
+        {
+        }
+
+        public ChessEngine(string enginePath, string? arguments)
         {
             this.enginePath = enginePath;
             this.engineArguments = arguments;


### PR DESCRIPTION
## Summary
- add explicit constructors for ChessEngine

## Testing
- `dotnet build AutoChess.Tests/AutoChess.Tests.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841db1c4f0083279dc3d789026fef7d