### PR TITLE
Fix stockfish path

### DIFF
--- a/AutoChess.Core/ChessEngine.cs
+++ b/AutoChess.Core/ChessEngine.cs
@@ -26,7 +26,7 @@ namespace AutoChess
 
 
 
-        public ChessEngine() : this("../../../stockfish/stockfish.exe", null)
+        public ChessEngine() : this("../AutoChess/stockfish/stockfish.exe", null)
         {
         }
 


### PR DESCRIPTION
## Summary
- fix default Stockfish path so chess engine can start

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e50c148c8327a355252c1285e7d7