### PR TITLE
Add basic web UI with chessboard simulation

### DIFF
--- a/AutoChess.Web/Program.cs
+++ b/AutoChess.Web/Program.cs
@@ -1,14 +1,58 @@
 using AutoChess;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddCors();
 var app = builder.Build();
+app.UseDefaultFiles();
+app.UseStaticFiles();
+app.UseCors(x => x.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
 
 var board = new Board();
 var engine = new ChessEngine();
 
+string GenerateRandomPosition()
+{
+    var pieces = new[] { 'p','r','n','b','q','k','P','R','N','B','Q','K' };
+    var rnd = new Random();
+    var sb = new StringBuilder();
+    for (int r = 0; r < 8; r++)
+    {
+        int empty = 0;
+        for (int c = 0; c < 8; c++)
+        {
+            if (rnd.NextDouble() < 0.5)
+            {
+                empty++;
+            }
+            else
+            {
+                if (empty > 0)
+                {
+                    sb.Append(empty);
+                    empty = 0;
+                }
+                sb.Append(pieces[rnd.Next(pieces.Length)]);
+            }
+        }
+        if (empty > 0) sb.Append(empty);
+        if (r < 7) sb.Append('/');
+    }
+    sb.Append(rnd.Next(2) == 0 ? " w " : " b ");
+    sb.Append("- - 0 1");
+    return sb.ToString();
+}
+
 app.MapGet("/", () => "AutoChess API running");
 
 app.MapGet("/board", () => board.GetFEN());
+
+app.MapGet("/board/random", () =>
+{
+    var fen = GenerateRandomPosition();
+    board.LoadFEN(fen);
+    return Results.Ok(board.GetFEN());
+});
 
 app.MapPost("/board/load", (string fen) =>
 {

--- a/AutoChess.Web/wwwroot/index.html
+++ b/AutoChess.Web/wwwroot/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>AutoChess</title>
+    <style>
+        table { border-collapse: collapse; margin-bottom: 10px; }
+        td {
+            width: 45px;
+            height: 45px;
+            text-align: center;
+            vertical-align: middle;
+            font-size: 32px;
+        }
+        .white { background: #f0d9b5; }
+        .black { background: #b58863; }
+        button { padding: 10px 20px; }
+    </style>
+</head>
+<body>
+    <table id="board"></table>
+    <button id="simulateBtn">Run Simulation</button>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/AutoChess.Web/wwwroot/script.js
+++ b/AutoChess.Web/wwwroot/script.js
@@ -1,0 +1,64 @@
+const symbols = {
+    'p': '♟', 'r': '♜', 'n': '♞', 'b': '♝', 'q': '♛', 'k': '♚',
+    'P': '♙', 'R': '♖', 'N': '♘', 'B': '♗', 'Q': '♕', 'K': '♔'
+};
+
+function createBoard() {
+    const table = document.getElementById('board');
+    for (let r = 0; r < 8; r++) {
+        const row = document.createElement('tr');
+        for (let c = 0; c < 8; c++) {
+            const cell = document.createElement('td');
+            cell.dataset.row = r;
+            cell.dataset.col = c;
+            cell.className = (r + c) % 2 === 0 ? 'white' : 'black';
+            row.appendChild(cell);
+        }
+        table.appendChild(row);
+    }
+}
+
+function parseFEN(fen) {
+    const rows = fen.split(' ')[0].split('/');
+    const board = [];
+    for (let r = 0; r < 8; r++) {
+        const row = [];
+        for (const ch of rows[r]) {
+            if (!isNaN(ch)) {
+                for (let i = 0; i < Number(ch); i++) row.push(' ');
+            } else {
+                row.push(ch);
+            }
+        }
+        board.push(row);
+    }
+    return board;
+}
+
+function renderBoard(arr) {
+    for (let r = 0; r < 8; r++) {
+        for (let c = 0; c < 8; c++) {
+            const cell = document.querySelector(`td[data-row='${r}'][data-col='${c}']`);
+            const piece = arr[r][c];
+            cell.textContent = symbols[piece] || '';
+        }
+    }
+}
+
+async function loadRandom() {
+    const res = await fetch('/board/random');
+    const fen = await res.text();
+    renderBoard(parseFEN(fen));
+}
+
+async function simulate() {
+    const res = await fetch('/move', { method: 'POST' });
+    const fen = await res.text();
+    renderBoard(parseFEN(fen));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    createBoard();
+    loadRandom();
+    document.getElementById('simulateBtn').addEventListener('click', simulate);
+});


### PR DESCRIPTION
## Summary
- serve static files from the web project
- expose `/board/random` endpoint for random starting positions
- add simple HTML/JS frontend that draws a chessboard and calls the backend

## Testing
- `dotnet test AutoChess.Tests/AutoChess.Tests.csproj` *(fails: assembly xunit.abstractions not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e659baf8832794c1aba224048c09