### PR TITLE
Fix board bounds and starting position

### DIFF
--- a/AutoChess.Core/Board.cs
+++ b/AutoChess.Core/Board.cs
@@ -112,11 +112,21 @@ namespace AutoChess
 
         public char GetPieceAt(int row, int col)
         {
+            if (row < 0 || row >= 8 || col < 0 || col >= 8)
+            {
+                return '\0';
+            }
+
             return board[row, col];
         }
 
         public void SetPieceAt(int row, int col, char piece)
         {
+            if (row < 0 || row >= 8 || col < 0 || col >= 8)
+            {
+                return;
+            }
+
             board[row, col] = piece;
         }
 

--- a/AutoChess.Web/Program.cs
+++ b/AutoChess.Web/Program.cs
@@ -9,6 +9,7 @@ app.UseStaticFiles();
 app.UseCors(x => x.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
 
 var board = new Board();
+board.LoadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
 var engine = new ChessEngine();
 
 string GenerateRandomPosition()


### PR DESCRIPTION
## Summary
- prevent board coordinate out of range exceptions
- load a default starting position when the web server starts

## Testing
- `dotnet test AutoChess.Tests/AutoChess.Tests.csproj -v m` *(fails: xunit.abstractions.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee991b0c8327a2f0a2f341d4fcf3